### PR TITLE
`use -g` instead of `x` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ And what you couldn't test locally, you test before you commit
 ## 📦 Installation
 
 ```bash
-mise x ubi:tuist/magnolia
+mise use -g ubi:tuist/magnolia
 ```
 
 Or download from [releases](https://github.com/tuist/magnolia/releases).


### PR DESCRIPTION
if this section is called "Installation", and other code examples are using non-prefixed `magnolia`, shouldn't this be `use -g` instead of `exec`?